### PR TITLE
use auto-redirect CRAN mirror (same as r-appveyor)

### DIFF
--- a/scripts/travis-tool.sh
+++ b/scripts/travis-tool.sh
@@ -8,8 +8,8 @@ set -x
 
 # REPOS is used for install_r, install_deps, and install_github.
 # CRAN is used for aptget_install, r_binary_install, and bioc_install.
-REPOS=${REPOS:-"c('http://cran.rstudio.com','http://owi.usgs.gov/R')"}
-CRAN=${CRAN:-"http://cran.rstudio.com"}
+REPOS=${REPOS:-"c('https://cloud.r-project.org','http://owi.usgs.gov/R')"}
+CRAN=${CRAN:-"https://cloud.r-project.org"}
 BIOC=${BIOC:-"http://bioconductor.org/biocLite.R"}
 BIOC_USE_DEVEL=${BIOC_USE_DEVEL:-"TRUE"}
 OS=$(uname -s)


### PR DESCRIPTION
At least in my projects, this r-travis script only ever gets used for Appveyor builds, so it's appropriate & useful to have it be consistent with what r-appveyor uses.

Travis builds whose travis.yml contains `language: r` use native R support (i.e., are handled somewhere within Travis) rather than referring to this script.

The new auto-redirect CRAN mirror, https://cloud.r-project.org, is supported by RStudio.